### PR TITLE
Register googleapis error details message types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Automatic expansion of standard Google error message types in [error details](https://cloud.google.com/apis/design/errors#error_details) by [@optiman](https://github.com/optiman)
+
 ### Fixed
 - Oneof value that has a message with no fields would cause the UI to become unresponsive
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5 // indirect
 	golang.org/x/net v0.0.0-20201022231255-08b38378de70 // indirect
 	golang.org/x/sys v0.0.0-20201022201747-fb209a7c41cd // indirect
-	google.golang.org/genproto v0.0.0-20201022181438-0ff5f38871d5 // indirect
+	google.golang.org/genproto v0.0.0-20201022181438-0ff5f38871d5
 	google.golang.org/grpc v1.33.1
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect

--- a/internal/app/api.go
+++ b/internal/app/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/wailsapp/wails"
 	"github.com/wailsapp/wails/cmd"
 	"github.com/wailsapp/wails/lib/logger"
+	_ "google.golang.org/genproto/googleapis/rpc/errdetails" // needed to register message types in init()
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"


### PR DESCRIPTION
[Richer error model](https://grpc.io/docs/guides/error/)
All `errdetails` types are registered in `init()` of `google.golang.org/genproto/googleapis/rpc/errdetails` package. 
Just needed to import it.

Before:
![before](https://user-images.githubusercontent.com/2707476/100684189-841a1900-3382-11eb-8e72-07a1cd8df403.png)

After:
![details](https://user-images.githubusercontent.com/2707476/100683849-d9095f80-3381-11eb-8316-a17166cd59d7.png)
