### PR TITLE
Update README.md with new way to use brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Visit the [Releases](https://github.com/rogchap/wombat/releases) page for the la
 Or via [Homebrew](https://brew.sh/)
 
 ```bash
-$ brew cask install wombat
+$ brew install --cask wombat
 ```
 
 If you get this error message: `"Wombat.app" can't be opened because the identity of the developer cannot be


### PR DESCRIPTION
Homebrew v2.7.0 disabled `brew cask install` and should now be `brew install --cask`

https://github.com/Homebrew/brew/pull/10056/files#diff-6b41cd34991fd4bf2887d97970060cd2c3303f29c13d51480dce512a9ebad369